### PR TITLE
Specify keys directly in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ To run the integration tests:
 
 - Download the file named "DLDV Structured Test Plan.xlsx" from Google Drive.
   Export it as a CSV and save the results
-- Save the AAMVA public and private keys and set the `AAMVA_PRIVATE_KEY_PATH`,
-  `AAMVA_PRIVATE_KEY_PASSPHRASE`, and `AAMVA_PUBLIC_KEY_PATH` appropriately in
+- Save the AAMVA public and private keys and set the `AAMVA_PRIVATE_KEY`, and
+  `AAMVA_PUBLIC_KEY` appropriately in
   a `.env` file.
 - Set `AAMVA_VERIFICATION_URL` to the AAMVA API url you wish to test in the
   `.env` file
@@ -51,9 +51,8 @@ To run the integration tests:
 This application uses the following environment variables:
 
 ```shell
-AAMVA_PRIVATE_KEY_PATH='/path/to/aamva-private-key.pem'
-AAMVA_PRIVATE_KEY_PASSPHRASE='sekret'
-AAMVA_PUBLIC_KEY_PATH='/path/to/aamva-public-key.crt'
+AAMVA_PRIVATE_KEY='base64privatekey'
+AAMVA_PUBLIC_KEY='base64publickey'
 AAMVA_VERIFICATION_URL='https://verificationservices-primary.aamva.org:18449/dldv/2.1/valuefree'
 AUTH_URL= 'https://authentication-cert.aamva.org/Authentication/Authenticate.svc'
 ```

--- a/lib/aamva/request/security_token_request.rb
+++ b/lib/aamva/request/security_token_request.rb
@@ -74,13 +74,14 @@ module Aamva
 
       def private_key
         @private_key ||= OpenSSL::PKey::RSA.new(
-          File.read(ENV['AAMVA_PRIVATE_KEY_PATH']),
-          ENV['AAMVA_PRIVATE_KEY_PASSPHRASE']
+          Base64.decode64(ENV['AAMVA_PRIVATE_KEY'])
         )
       end
 
       def public_key
-        @public_key ||= OpenSSL::X509::Certificate.new(File.read(ENV['AAMVA_PUBLIC_KEY_PATH']))
+        @public_key ||= OpenSSL::X509::Certificate.new(
+          Base64.decode64(ENV['AAMVA_PUBLIC_KEY'])
+        )
       end
 
       def reply_to_uuid

--- a/spec/lib/aamva/authentication_client_spec.rb
+++ b/spec/lib/aamva/authentication_client_spec.rb
@@ -38,6 +38,11 @@ describe Aamva::AuthenticationClient do
     end
 
     context 'when the auth token is nil' do
+      before do
+        Aamva::AuthenticationClient.auth_token = nil
+        Aamva::AuthenticationClient.auth_token_expiration = nil
+      end
+
       it 'should send an authentication request then save and return the token' do
         token = subject.fetch_token
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,9 +4,6 @@ $LOAD_PATH.unshift File.dirname(__FILE__) + '/../lib'
 require 'pry-byebug'
 require 'dotenv'
 
-require File.dirname(__FILE__) + '/support/env_overrides.rb'
-EnvOverrides.set_test_environment_variables
-
 require 'aamva'
 require 'proofer/vendor/aamva'
 require 'proofer'
@@ -16,6 +13,8 @@ require 'httpi'
 HTTPI.log = false
 
 Dir[File.dirname(__FILE__) + '/support/*.rb'].sort.each { |file| require file }
+
+EnvOverrides.set_test_environment_variables
 
 RSpec.configure do |config|
   config.color = true

--- a/spec/support/env_overrides.rb
+++ b/spec/support/env_overrides.rb
@@ -1,14 +1,9 @@
+require 'base64'
+
 module EnvOverrides
   def self.set_test_environment_variables
-    ENV['AAMVA_PRIVATE_KEY_PATH'] = File.join(
-      File.dirname(__FILE__),
-      '../fixtures/keys/aamva-private-key.example.pem'
-    )
-    ENV['AAMVA_PUBLIC_KEY_PATH'] = File.join(
-      File.dirname(__FILE__),
-      '../fixtures/keys/aamva-public-key.example.crt'
-    )
-    ENV['AAMVA_PRIVATE_KEY_PASSPHRASE'] = 'sekret'
+    ENV['AAMVA_PRIVATE_KEY'] = Base64.strict_encode64 Fixtures.aamva_private_key.to_der
+    ENV['AAMVA_PUBLIC_KEY'] = Base64.strict_encode64 Fixtures.aamva_public_key.to_der
     ENV['AAMVA_VERIFICATION_URL'] =
       'https://verificationservices-primary.aamva.org:18449/dldv/2.1/valuefree'
     ENV['AUTH_URL'] =


### PR DESCRIPTION
**Why**: Specifying a base64 encoded key in the config allows us to use
the config to manage the keys instead of having to add them to the
filesystem on the hosts.