### PR TITLE
Stop hardcoding message destination id

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ To run the integration tests:
 - Set `AAMVA_VERIFICATION_URL` to the AAMVA API url you wish to test in the
   `.env` file
 - Set `AUTH_URL` to the auth  url you wish to test in the `.env` file
+- Set 'AAMVA_CERT_ENABLED' if you are using test data for the AAMVA cert environment
 - Run `rspec spec/integration/`
 
 # Environment variables

--- a/lib/aamva/request/verification_request.rb
+++ b/lib/aamva/request/verification_request.rb
@@ -55,7 +55,8 @@ module Aamva
       end
 
       def message_destination_id
-        'P6' # TODO State or test destination
+        return 'P6' if ENV['AAMVA_CERT_ENABLED'] == 'true'
+        applicant.state_id_data.state_id_jurisdiction
       end
 
       def request_body_template

--- a/spec/fixtures/requests/verification_request.xml
+++ b/spec/fixtures/requests/verification_request.xml
@@ -14,7 +14,7 @@
               1234-abcd-efgh
             </ns1:TransactionLocatorId>
             <ns1:MessageOriginatorId>GSA</ns1:MessageOriginatorId>
-            <ns1:MessageDestinationId>P6</ns1:MessageDestinationId>
+            <ns1:MessageDestinationId>CA</ns1:MessageDestinationId>
           </ns1:MessageAddress>
         </ns1:ControlData>
         <ns2:DriverLicenseIdentification>

--- a/spec/support/env_overrides.rb
+++ b/spec/support/env_overrides.rb
@@ -2,6 +2,7 @@ require 'base64'
 
 module EnvOverrides
   def self.set_test_environment_variables
+    ENV['AAMVA_CERT_ENABLED'] = 'false'
     ENV['AAMVA_PRIVATE_KEY'] = Base64.strict_encode64 Fixtures.aamva_private_key.to_der
     ENV['AAMVA_PUBLIC_KEY'] = Base64.strict_encode64 Fixtures.aamva_public_key.to_der
     ENV['AAMVA_VERIFICATION_URL'] =


### PR DESCRIPTION
**Why**: The message destination ID is supposed to be sent to the state
who has the data that we are verifying against. We've been hardcoding it
to a test state provided by AAMVA. This commit changes it to be the test
state if we are in the CERT environment, and the actual state if we are
not.