### PR TITLE
Parse error message from SOAP Program Exceptions

### DIFF
--- a/spec/fixtures/responses/soap_fault_response.xml
+++ b/spec/fixtures/responses/soap_fault_response.xml
@@ -23,6 +23,13 @@
             <ExceptionFatalIndicatorCode>true</ExceptionFatalIndicatorCode>
             <ExceptionActorText>DLDV VSS</ExceptionActorText>
           </ProgramException>
+          <ProgramException>
+            <ExceptionId>0048</ExceptionId>
+            <ExceptionText>Servers are experiencing higher than regular traffic</ExceptionText>
+            <ExceptionTypeCode>J</ExceptionTypeCode>
+            <ExceptionFatalIndicatorCode>true</ExceptionFatalIndicatorCode>
+            <ExceptionActorText>DLDV VSS</ExceptionActorText>
+          </ProgramException>
         </ProgramExceptions>
       </Exception>
     </s:Fault>

--- a/spec/integration/state_id_proofing_spec.rb
+++ b/spec/integration/state_id_proofing_spec.rb
@@ -20,10 +20,14 @@ describe 'State ID proofing' do
       agent = Proofer::Agent.new(vendor: :aamva, applicant: applicant)
 
       if row['MVA Timeout'] == 'TRUE'
-        expect { agent.submit_state_id(state_id_data(row)) }.to raise_error(
-          Aamva::VerificationError,
-          'DLDV VSS'
-        )
+        error = begin
+          agent.submit_state_id(state_id_data(row))
+        rescue Aamva::VerificationError => e
+          e
+        end
+
+        expect(error).to be_kind_of(Aamva::VerificationError)
+        expect(error.message).to include('MVA did not respond in a timely fashion')
       else
         response = agent.submit_state_id(state_id_data(row))
         expect(response.success?).to eq(true)

--- a/spec/lib/aamva/response/authentication_token_response_spec.rb
+++ b/spec/lib/aamva/response/authentication_token_response_spec.rb
@@ -22,7 +22,7 @@ describe Aamva::Response::AuthenticationTokenResponse do
     end
 
     context 'when the API response has an error' do
-      let(:response_body) { Fixtures.soap_fault_response }
+      let(:response_body) { Fixtures.soap_fault_response_simplified }
 
       it 'raises an AuthenticationError' do
         expect { subject }.to raise_error(

--- a/spec/lib/aamva/response/security_token_response_spec.rb
+++ b/spec/lib/aamva/response/security_token_response_spec.rb
@@ -24,7 +24,7 @@ describe Aamva::Response::SecurityTokenResponse do
     end
 
     context 'when the API response is an error' do
-      let(:response_body) { Fixtures.soap_fault_response }
+      let(:response_body) { Fixtures.soap_fault_response_simplified }
 
       it 'raises an AuthenticationError' do
         expect { subject }.to raise_error(

--- a/spec/lib/aamva/response/verification_response_spec.rb
+++ b/spec/lib/aamva/response/verification_response_spec.rb
@@ -36,7 +36,7 @@ describe Aamva::Response::VerificationResponse do
     end
 
     context 'when the API response has an error' do
-      let(:response_body) { Fixtures.soap_fault_response }
+      let(:response_body) { Fixtures.soap_fault_response_simplified }
 
       it 'raises a VerificationError' do
         expect { subject }.to raise_error(

--- a/spec/lib/aamva/soap_error_handler_spec.rb
+++ b/spec/lib/aamva/soap_error_handler_spec.rb
@@ -26,6 +26,31 @@ describe Aamva::SoapErrorHander do
     end
 
     context 'when there is an error' do
+      it 'contains relevant parts of the error message' do
+        expect(subject.error_message).to include('A FooBar error occurred')
+
+        expect(subject.error_message).to include('ExceptionId: 0047')
+        expect(subject.error_message).to include(
+          'ExceptionText: MVA did not respond in a timely fashion'
+        )
+        expect(subject.error_message).to include('ExceptionTypeCode: I')
+
+        expect(subject.error_message).to include('ExceptionId: 0048')
+        expect(subject.error_message).to include(
+          'Servers are experiencing higher than regular traffic'
+        )
+        expect(subject.error_message).to include('ExceptionTypeCode: J')
+      end
+    end
+
+    context 'when there is an error without a ProgramException section' do
+      let(:response_body) do
+        delete_xml_at_xpath(
+          Fixtures.soap_fault_response,
+          '//ProgramExceptions'
+        )
+      end
+
       it { expect(subject.error_message).to eq('A FooBar error occurred') }
     end
 
@@ -37,7 +62,7 @@ describe Aamva::SoapErrorHander do
         )
       end
 
-      it { expect(subject.error_message).to eq('A SOAP error occurred') }
+      it { expect(subject.error_message).to include('A SOAP error occurred') }
     end
   end
 end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -41,6 +41,13 @@ module Fixtures
     read_fixture_file('responses/soap_fault_response.xml')
   end
 
+  def self.soap_fault_response_simplified
+    XmlHelpers.delete_xml_at_xpath(
+      soap_fault_response,
+      '//ProgramExceptions'
+    )
+  end
+
   def self.verification_request
     read_fixture_file('requests/verification_request.xml').
       gsub(/^\s+/, '').

--- a/spec/support/xml_helpers.rb
+++ b/spec/support/xml_helpers.rb
@@ -19,4 +19,5 @@ module XmlHelpers
     element.parent.delete(element)
     document.to_s
   end
+  module_function :delete_xml_at_xpath
 end


### PR DESCRIPTION
**Why**: Because the program exception has helpful information.
Currently we are only reading from the SOAP Fault "Reason" parts of the
error message body which often just contains a title of the message like
"DLDV Error" which is not very helpful.