### PR TITLE
Don't raise when attributes are missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ tmp/
 *.crt
 *.PFX
 fixtures/aamva_test_data.csv
+fixtures/*_test_data.csv
 .overcommit.yml

--- a/lib/aamva/version.rb
+++ b/lib/aamva/version.rb
@@ -1,3 +1,3 @@
 module Aamva
-  VERSION = '0.1.0'.freeze
+  VERSION = '1.0.3'.freeze
 end

--- a/lib/proofer/vendor/aamva.rb
+++ b/lib/proofer/vendor/aamva.rb
@@ -19,7 +19,8 @@ module Proofer
       def build_state_id_error(response)
         errors = {}
         response.verification_results.each do |attribute, result|
-          errors[attribute] = 'UNVERIFIED' unless result == true
+          errors[attribute] = 'UNVERIFIED' if result == false
+          errors[attribute] = 'MISSING' if result.nil?
         end
         errors
       end

--- a/spec/lib/proofer/vendor/aamva_spec.rb
+++ b/spec/lib/proofer/vendor/aamva_spec.rb
@@ -73,5 +73,19 @@ describe Proofer::Vendor::Aamva do
         expect(response.errors).to eq(dob: 'UNVERIFIED', zipcode: 'UNVERIFIED')
       end
     end
+
+    context 'when verification attributes are missing' do
+      let(:success) { false }
+      let(:verification_results) { super().merge(dob: false, zipcode: nil) }
+
+      it 'should return a failed confirmation' do
+        response = subject.submit_state_id(state_id_data, session_id)
+
+        expect(response).to be_a(Proofer::Confirmation)
+        expect(response.success?).to eq(false)
+        expect(response.vendor_resp).to eq(aamva_response)
+        expect(response.errors).to eq(dob: 'UNVERIFIED', zipcode: 'MISSING')
+      end
+    end
   end
 end


### PR DESCRIPTION
**Why**: There are cases when AAMVA's DLDV API does not respond because
there was nothing to match against (e.g. lookup by driver's license
number failed). This commit adds the missing attribute to the errors
hash, but does not raise if an attribute is missing.

Internally, it tracks missing verification attributes by setting the
value in the response's `verification_results` hash to `nil` if an
attribute is missing.