### PR TITLE
Add 'AAMVA' to timeout message

### DIFF
--- a/lib/aamva/timeout_error_handler.rb
+++ b/lib/aamva/timeout_error_handler.rb
@@ -7,7 +7,7 @@ module Aamva
 
     def call
       return unless http_response.timed_out?
-      raise ::Proofer::TimeoutError, "Timed out waiting for #{context} response"
+      raise ::Proofer::TimeoutError, "AAMVA timed out waiting for #{context} response"
     end
 
     private

--- a/lib/aamva/version.rb
+++ b/lib/aamva/version.rb
@@ -1,3 +1,3 @@
 module Aamva
-  VERSION = '3.2.0'.freeze
+  VERSION = '3.2.1'.freeze
 end

--- a/spec/lib/aamva/response/authentication_token_response_spec.rb
+++ b/spec/lib/aamva/response/authentication_token_response_spec.rb
@@ -17,7 +17,7 @@ describe Aamva::Response::AuthenticationTokenResponse do
       it 'raises a timeout error' do
         expect { subject }.to raise_error(
           Proofer::TimeoutError,
-          'Timed out waiting for authentication token response'
+          'AAMVA timed out waiting for authentication token response'
         )
       end
     end

--- a/spec/lib/aamva/response/security_token_response_spec.rb
+++ b/spec/lib/aamva/response/security_token_response_spec.rb
@@ -21,7 +21,7 @@ describe Aamva::Response::SecurityTokenResponse do
       it 'raises a timeout error' do
         expect { subject }.to raise_error(
           Proofer::TimeoutError,
-          'Timed out waiting for security token response'
+          'AAMVA timed out waiting for security token response'
         )
       end
     end

--- a/spec/lib/aamva/response/verification_response_spec.rb
+++ b/spec/lib/aamva/response/verification_response_spec.rb
@@ -29,7 +29,7 @@ describe Aamva::Response::VerificationResponse do
       it 'raises a timeout error' do
         expect { subject }.to raise_error(
           Proofer::TimeoutError,
-          'Timed out waiting for verification response'
+          'AAMVA timed out waiting for verification response'
         )
       end
     end


### PR DESCRIPTION
**Why**: So that it is possible to determine which vendor is timing out
in the analytics logs