### PR TITLE
LG-2123 Log Faraday error messages

### DIFF
--- a/lib/aamva/request/authentication_token_request.rb
+++ b/lib/aamva/request/authentication_token_request.rb
@@ -37,10 +37,8 @@ module Aamva
           http_client.post(url, body, headers)
         )
       rescue Faraday::TimeoutError, Faraday::ConnectionFailed => err
-        raise(
-          ::Proofer::TimeoutError,
-          "AAMVA raised #{err.class} waiting for authentication token response",
-        )
+        message = "AAMVA raised #{err.class} waiting for authentication token response: #{err.message}"
+        raise ::Proofer::TimeoutError, message
       end
 
       def self.auth_url

--- a/lib/aamva/request/security_token_request.rb
+++ b/lib/aamva/request/security_token_request.rb
@@ -31,7 +31,8 @@ module Aamva
           http_client.post(url, body, headers)
         )
       rescue Faraday::TimeoutError, Faraday::ConnectionFailed => err
-        raise ::Proofer::TimeoutError, "AAMVA raised #{err.class} waiting for security token response"
+        message = "AAMVA raised #{err.class} waiting for security token response: #{err.message}"
+        raise ::Proofer::TimeoutError, message
       end
 
       def self.auth_url

--- a/lib/aamva/request/verification_request.rb
+++ b/lib/aamva/request/verification_request.rb
@@ -32,7 +32,8 @@ module Aamva
           http_client.post(url, body, headers)
         )
       rescue Faraday::TimeoutError, Faraday::ConnectionFailed => err
-        raise ::Proofer::TimeoutError, "AAMVA raised #{err.class} waiting for verification response"
+        message = "AAMVA raised #{err.class} waiting for verification response: #{err.message}"
+        raise ::Proofer::TimeoutError, message
       end
 
       def self.verification_url

--- a/lib/aamva/version.rb
+++ b/lib/aamva/version.rb
@@ -1,3 +1,3 @@
 module Aamva
-  VERSION = '3.2.3'.freeze
+  VERSION = '3.2.4'.freeze
 end

--- a/spec/lib/aamva/request/authentication_token_request_spec.rb
+++ b/spec/lib/aamva/request/authentication_token_request_spec.rb
@@ -73,7 +73,7 @@ describe Aamva::Request::AuthenticationTokenRequest do
 
         expect { subject.send }.to raise_error(
           ::Proofer::TimeoutError,
-          'AAMVA raised Faraday::TimeoutError waiting for authentication token response',
+          'AAMVA raised Faraday::TimeoutError waiting for authentication token response: timeout',
         )
       end
     end
@@ -87,7 +87,7 @@ describe Aamva::Request::AuthenticationTokenRequest do
 
         expect { subject.send }.to raise_error(
           ::Proofer::TimeoutError,
-          'AAMVA raised Faraday::ConnectionFailed waiting for authentication token response',
+          'AAMVA raised Faraday::ConnectionFailed waiting for authentication token response: error',
         )
       end
     end

--- a/spec/lib/aamva/request/security_token_request_spec.rb
+++ b/spec/lib/aamva/request/security_token_request_spec.rb
@@ -81,7 +81,7 @@ describe Aamva::Request::SecurityTokenRequest do
 
         expect { subject.send }.to raise_error(
           ::Proofer::TimeoutError,
-          'AAMVA raised Faraday::TimeoutError waiting for security token response',
+          'AAMVA raised Faraday::TimeoutError waiting for security token response: timeout',
         )
       end
     end
@@ -95,7 +95,7 @@ describe Aamva::Request::SecurityTokenRequest do
 
         expect { subject.send }.to raise_error(
           ::Proofer::TimeoutError,
-          'AAMVA raised Faraday::ConnectionFailed waiting for security token response',
+          'AAMVA raised Faraday::ConnectionFailed waiting for security token response: error',
         )
       end
     end

--- a/spec/lib/aamva/request/verification_request_spec.rb
+++ b/spec/lib/aamva/request/verification_request_spec.rb
@@ -84,7 +84,7 @@ describe Aamva::Request::VerificationRequest do
 
         expect { subject.send }.to raise_error(
           ::Proofer::TimeoutError,
-          'AAMVA raised Faraday::TimeoutError waiting for verification response',
+          'AAMVA raised Faraday::TimeoutError waiting for verification response: timeout',
         )
       end
     end
@@ -98,7 +98,7 @@ describe Aamva::Request::VerificationRequest do
 
         expect { subject.send }.to raise_error(
           ::Proofer::TimeoutError,
-          'AAMVA raised Faraday::ConnectionFailed waiting for verification response',
+          'AAMVA raised Faraday::ConnectionFailed waiting for verification response: error',
         )
       end
     end


### PR DESCRIPTION
**Why**: The error messages give some help info about timeouts and connection failures that currently we are losing