### PR TITLE
LG-3031 Change AUTH_URL config to AAMVA_AUTH_URL

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,10 +6,10 @@
 
 AllCops:
   Include:
-    - '**/Gemfile'
-    - '**/Rakefile'
-    - '**/Capfile'
-    - '**/*.rb'
+    - "**/Gemfile"
+    - "**/Rakefile"
+    - "**/Capfile"
+    - "**/*.rb"
   TargetRubyVersion: 2.5
   UseCache: true
 
@@ -19,17 +19,17 @@ Metrics/AbcSize:
   Enabled: true
   Max: 15
   Exclude:
-  - spec/**/*
+    - spec/**/*
 
 Metrics/BlockLength:
-  CountComments: false  # count full line comments?
+  CountComments: false # count full line comments?
   Enabled: true
   Max: 25
   Exclude:
-    - 'Rakefile'
-    - '**/*.rake'
-    - 'spec/**/*.rb'
-    - '*.gemspec'
+    - "Rakefile"
+    - "**/*.rake"
+    - "spec/**/*.rb"
+    - "*.gemspec"
 
 Metrics/ClassLength:
   Description: Avoid classes longer than 100 lines of code.
@@ -37,7 +37,7 @@ Metrics/ClassLength:
   CountComments: false
   Max: 100
   Exclude:
-  - spec/**/*
+    - spec/**/*
 
 Metrics/LineLength:
   Description: Limit lines to 100 characters.
@@ -46,8 +46,8 @@ Metrics/LineLength:
   Max: 100
   AllowURI: true
   URISchemes:
-  - http
-  - https
+    - http
+    - https
 
 Metrics/MethodLength:
   Description: Avoid methods longer than 10 lines of code.
@@ -56,7 +56,7 @@ Metrics/MethodLength:
   CountComments: false
   Max: 10
   Exclude:
-  - spec/**/*
+    - spec/**/*
 
 Metrics/ModuleLength:
   CountComments: false
@@ -64,7 +64,7 @@ Metrics/ModuleLength:
   Description: Avoid modules longer than 100 lines of code.
   Enabled: true
   Exclude:
-  - spec/**/*
+    - spec/**/*
 
 Metrics/ParameterLists:
   CountKeywordArgs: false
@@ -84,9 +84,9 @@ Layout/AlignParameters:
   #     method_call(a,
   #       b)
   Description: >-
-                 Align the parameters of a method call if they span more
-                 than one line.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-double-indent'
+    Align the parameters of a method call if they span more
+    than one line.
+  StyleGuide: "https://github.com/bbatsov/ruby-style-guide#no-double-indent"
   EnforcedStyle: with_first_parameter
   SupportedStyles:
     - with_first_parameter
@@ -100,23 +100,23 @@ Style/AndOr:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-and-or-or
   EnforcedStyle: conditionals
   SupportedStyles:
-  - always
-  - conditionals
+    - always
+    - conditionals
 
 Style/Documentation:
   Description: Document classes and non-namespace modules.
   Enabled: false
   Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
+    - "spec/**/*"
+    - "test/**/*"
 
 Layout/DotPosition:
   Description: Checks the position of the dot in multi-line method calls.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains
   EnforcedStyle: trailing
   SupportedStyles:
-  - leading
-  - trailing
+    - leading
+    - trailing
 
 # Warn on empty else statements
 # empty - warn only on empty else
@@ -139,12 +139,12 @@ Layout/ExtraSpacing:
 
 Style/FrozenStringLiteralComment:
   Description: >-
-                 Add the frozen_string_literal comment to the top of files
-                 to help transition from Ruby 2.3.0 to Ruby 3.0.
+    Add the frozen_string_literal comment to the top of files
+    to help transition from Ruby 2.3.0 to Ruby 3.0.
   Enabled: false
 
 # Checks the indentation of the first element in an array literal.
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   # The value `special_inside_parentheses` means that array literals with
   # brackets that have their opening bracket on the same line as a surrounding
   # opening round parenthesis, shall have their first element indented relative
@@ -180,17 +180,17 @@ Style/PercentLiteralDelimiters:
   # an individual key
   PreferredDelimiters:
     default: ()
-    '%i': '[]'
-    '%I': '[]'
-    '%r': '{}'
-    '%w': '[]'
-    '%W': '[]'
+    "%i": "[]"
+    "%I": "[]"
+    "%r": "{}"
+    "%w": "[]"
+    "%W": "[]"
 
 Style/SafeNavigation:
   Description: >-
-                  This cop transforms usages of a method call safeguarded by
-                  a check for the existance of the object to
-                  safe navigation (`&.`).
+    This cop transforms usages of a method call safeguarded by
+    a check for the existance of the object to
+    safe navigation (`&.`).
   Enabled: false
 
 Style/StringLiterals:
@@ -198,8 +198,8 @@ Style/StringLiterals:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-string-literals
   EnforcedStyle: single_quotes
   SupportedStyles:
-  - single_quotes
-  - double_quotes
+    - single_quotes
+    - double_quotes
   ConsistentQuotesInMultiline: true
 
 Style/TrailingCommaInArguments:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -207,7 +207,7 @@ Style/TrailingCommaInArguments:
   # parenthesized method calls where each argument is on its own line.
   # If `consistent_comma`, the cop requires a comma after the last argument,
   # for all parenthesized method calls with arguments.
-  EnforcedStyleForMultiline: no_comma
+  EnforcedStyleForMultiline: comma
   SupportedStylesForMultiline:
     - comma
     - consistent_comma

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To run the integration tests:
   a `.env` file.
 - Set `AAMVA_VERIFICATION_URL` to the AAMVA API url you wish to test in the
   `.env` file
-- Set `AUTH_URL` to the auth  url you wish to test in the `.env` file
+- Set `AAMVA_AUTH_URL` to the auth url you wish to test in the `.env` file
 - Set 'AAMVA_CERT_ENABLED' if you are using test data for the AAMVA cert environment
 - Run `rspec spec/integration/`
 
@@ -55,5 +55,5 @@ This application uses the following environment variables:
 AAMVA_PRIVATE_KEY='base64privatekey'
 AAMVA_PUBLIC_KEY='base64publickey'
 AAMVA_VERIFICATION_URL='https://verificationservices-primary.aamva.org:18449/dldv/2.1/valuefree'
-AUTH_URL= 'https://authentication-cert.aamva.org/Authentication/Authenticate.svc'
+AAMVA_AUTH_URL= 'https://authentication-cert.aamva.org/Authentication/Authenticate.svc'
 ```

--- a/lib/aamva/request/authentication_token_request.rb
+++ b/lib/aamva/request/authentication_token_request.rb
@@ -34,10 +34,10 @@ module Aamva
 
       def send
         Response::AuthenticationTokenResponse.new(
-          http_client.post(url, body, headers)
+          http_client.post(url, body, headers),
         )
-      rescue Faraday::TimeoutError, Faraday::ConnectionFailed => err
-        message = "AAMVA raised #{err.class} waiting for authentication token response: #{err.message}"
+      rescue Faraday::TimeoutError, Faraday::ConnectionFailed => e
+        message = "AAMVA raised #{e.class} waiting for authentication token response: #{e.message}"
         raise ::Proofer::TimeoutError, message
       end
 
@@ -78,7 +78,7 @@ module Aamva
       def request_body_template
         template_file_path = File.join(
           File.dirname(__FILE__),
-          'templates/authentication_token.xml.erb'
+          'templates/authentication_token.xml.erb',
         )
         File.read(template_file_path)
       end

--- a/lib/aamva/request/authentication_token_request.rb
+++ b/lib/aamva/request/authentication_token_request.rb
@@ -42,7 +42,7 @@ module Aamva
       end
 
       def self.auth_url
-        Env.fetch('AUTH_URL', DEFAULT_AUTH_URL)
+        Env.fetch('AAMVA_AUTH_URL', DEFAULT_AUTH_URL)
       end
 
       private

--- a/lib/aamva/request/security_token_request.rb
+++ b/lib/aamva/request/security_token_request.rb
@@ -36,7 +36,7 @@ module Aamva
       end
 
       def self.auth_url
-        Env.fetch('AUTH_URL', DEFAULT_AUTH_URL)
+        Env.fetch('AAMVA_AUTH_URL', DEFAULT_AUTH_URL)
       end
 
       private

--- a/spec/lib/aamva/request/authentication_token_request_spec.rb
+++ b/spec/lib/aamva/request/authentication_token_request_spec.rb
@@ -9,7 +9,7 @@ describe Aamva::Request::AuthenticationTokenRequest do
       security_context_token_identifier: security_context_token_identifier,
       security_context_token_reference: security_context_token_reference,
       client_hmac_secret: client_hmac_secret,
-      server_hmac_secret: server_hmac_secret
+      server_hmac_secret: server_hmac_secret,
     )
   end
 
@@ -32,7 +32,7 @@ describe Aamva::Request::AuthenticationTokenRequest do
         'SOAPAction' =>
           '"http://aamva.org/authentication/3.1.0/IAuthenticationService/Authenticate"',
         'Content-Type' => 'application/soap+xml;charset=UTF-8',
-        'Content-Length' => subject.body.length.to_s
+        'Content-Length' => subject.body.length.to_s,
       )
     end
   end
@@ -40,7 +40,7 @@ describe Aamva::Request::AuthenticationTokenRequest do
   describe '#url' do
     it 'should be the AAMVA authentication url' do
       expect(subject.url).to eq(
-        'https://authentication-cert.example.com/Authentication/Authenticate.svc'
+        'https://authentication-cert.example.com/Authentication/Authenticate.svc',
       )
     end
   end
@@ -73,7 +73,7 @@ describe Aamva::Request::AuthenticationTokenRequest do
 
         expect { subject.send }.to raise_error(
           ::Proofer::TimeoutError,
-          'AAMVA raised Faraday::TimeoutError waiting for authentication token response: timeout'
+          'AAMVA raised Faraday::TimeoutError waiting for authentication token response: timeout',
         )
       end
     end
@@ -87,7 +87,7 @@ describe Aamva::Request::AuthenticationTokenRequest do
 
         expect { subject.send }.to raise_error(
           ::Proofer::TimeoutError,
-          'AAMVA raised Faraday::ConnectionFailed waiting for authentication token response: error'
+          'AAMVA raised Faraday::ConnectionFailed waiting for authentication token response: error',
         )
       end
     end

--- a/spec/lib/aamva/request/authentication_token_request_spec.rb
+++ b/spec/lib/aamva/request/authentication_token_request_spec.rb
@@ -40,7 +40,7 @@ describe Aamva::Request::AuthenticationTokenRequest do
   describe '#url' do
     it 'should be the AAMVA authentication url' do
       expect(subject.url).to eq(
-        'https://authentication-cert.aamva.org/Authentication/Authenticate.svc'
+        'https://authentication-cert.example.com/Authentication/Authenticate.svc'
       )
     end
   end
@@ -73,7 +73,7 @@ describe Aamva::Request::AuthenticationTokenRequest do
 
         expect { subject.send }.to raise_error(
           ::Proofer::TimeoutError,
-          'AAMVA raised Faraday::TimeoutError waiting for authentication token response: timeout',
+          'AAMVA raised Faraday::TimeoutError waiting for authentication token response: timeout'
         )
       end
     end
@@ -87,7 +87,7 @@ describe Aamva::Request::AuthenticationTokenRequest do
 
         expect { subject.send }.to raise_error(
           ::Proofer::TimeoutError,
-          'AAMVA raised Faraday::ConnectionFailed waiting for authentication token response: error',
+          'AAMVA raised Faraday::ConnectionFailed waiting for authentication token response: error'
         )
       end
     end

--- a/spec/lib/aamva/request/security_token_request_spec.rb
+++ b/spec/lib/aamva/request/security_token_request_spec.rb
@@ -48,7 +48,7 @@ describe Aamva::Request::SecurityTokenRequest do
   describe '#url' do
     it 'should be the AAMVA authentication url' do
       expect(subject.url).to eq(
-        'https://authentication-cert.aamva.org/Authentication/Authenticate.svc'
+        'https://authentication-cert.example.com/Authentication/Authenticate.svc'
       )
     end
   end
@@ -81,7 +81,7 @@ describe Aamva::Request::SecurityTokenRequest do
 
         expect { subject.send }.to raise_error(
           ::Proofer::TimeoutError,
-          'AAMVA raised Faraday::TimeoutError waiting for security token response: timeout',
+          'AAMVA raised Faraday::TimeoutError waiting for security token response: timeout'
         )
       end
     end
@@ -95,7 +95,7 @@ describe Aamva::Request::SecurityTokenRequest do
 
         expect { subject.send }.to raise_error(
           ::Proofer::TimeoutError,
-          'AAMVA raised Faraday::ConnectionFailed waiting for security token response: error',
+          'AAMVA raised Faraday::ConnectionFailed waiting for security token response: error'
         )
       end
     end

--- a/spec/lib/aamva/request/security_token_request_spec.rb
+++ b/spec/lib/aamva/request/security_token_request_spec.rb
@@ -40,7 +40,7 @@ describe Aamva::Request::SecurityTokenRequest do
         'SOAPAction' =>
           '"http://aamva.org/authentication/3.1.0/IAuthenticationService/Authenticate"',
         'Content-Type' => 'application/soap+xml;charset=UTF-8',
-        'Content-Length' => subject.body.length.to_s
+        'Content-Length' => subject.body.length.to_s,
       )
     end
   end
@@ -48,7 +48,7 @@ describe Aamva::Request::SecurityTokenRequest do
   describe '#url' do
     it 'should be the AAMVA authentication url' do
       expect(subject.url).to eq(
-        'https://authentication-cert.example.com/Authentication/Authenticate.svc'
+        'https://authentication-cert.example.com/Authentication/Authenticate.svc',
       )
     end
   end
@@ -81,7 +81,7 @@ describe Aamva::Request::SecurityTokenRequest do
 
         expect { subject.send }.to raise_error(
           ::Proofer::TimeoutError,
-          'AAMVA raised Faraday::TimeoutError waiting for security token response: timeout'
+          'AAMVA raised Faraday::TimeoutError waiting for security token response: timeout',
         )
       end
     end
@@ -95,7 +95,7 @@ describe Aamva::Request::SecurityTokenRequest do
 
         expect { subject.send }.to raise_error(
           ::Proofer::TimeoutError,
-          'AAMVA raised Faraday::ConnectionFailed waiting for security token response: error'
+          'AAMVA raised Faraday::ConnectionFailed waiting for security token response: error',
         )
       end
     end

--- a/spec/support/env_overrides.rb
+++ b/spec/support/env_overrides.rb
@@ -6,8 +6,8 @@ module EnvOverrides
     ENV['AAMVA_PRIVATE_KEY'] = Base64.strict_encode64 Fixtures.aamva_private_key.to_der
     ENV['AAMVA_PUBLIC_KEY'] = Base64.strict_encode64 Fixtures.aamva_public_key.to_der
     ENV['AAMVA_VERIFICATION_URL'] =
-      'https://verificationservices-primary.aamva.org:18449/dldv/2.1/valuefree'
-    ENV['AUTH_URL'] =
-      'https://authentication-cert.aamva.org/Authentication/Authenticate.svc'
+      'https://verificationservices-primary.example.com:18449/dldv/2.1/valuefree'
+    ENV['AAMVA_AUTH_URL'] =
+      'https://authentication-cert.example.com/Authentication/Authenticate.svc'
   end
 end


### PR DESCRIPTION
**Why**: The of the config values in this repo match the names that we use in the IdP. In the IdP config, it is not obvious that `AUTH_URL` is the config for the AAMVA auth URL.

I changed the URLs we use in the unit tests to not match the defaults. I did this to make sure that I did not drop a config somewhere and it wasn't falling back to the defaults.