### PR TITLE
LG-3032 Remove the hardcoded URLs from the auth and security token requests

### DIFF
--- a/lib/aamva/request/authentication_token_request.rb
+++ b/lib/aamva/request/authentication_token_request.rb
@@ -27,9 +27,9 @@ module Aamva
         self.security_context_token_identifier = security_context_token_identifier
         self.security_context_token_reference = security_context_token_reference
         self.hmac_secret = HmacSecret.new(client_hmac_secret, server_hmac_secret).psha1
+        @url = AuthenticationTokenRequest.auth_url
         @body = build_request_body
         @headers = build_request_headers
-        @url = AuthenticationTokenRequest.auth_url
       end
 
       def send

--- a/lib/aamva/request/security_token_request.rb
+++ b/lib/aamva/request/security_token_request.rb
@@ -17,9 +17,9 @@ module Aamva
       attr_reader :body, :headers, :url
 
       def initialize
+        @url = SecurityTokenRequest.auth_url
         @body = build_request_body
         @headers = build_request_headers
-        @url = SecurityTokenRequest.auth_url
       end
 
       def nonce
@@ -28,7 +28,7 @@ module Aamva
 
       def send
         Response::SecurityTokenResponse.new(
-          http_client.post(url, body, headers)
+          http_client.post(url, body, headers),
         )
       rescue Faraday::TimeoutError, Faraday::ConnectionFailed => err
         message = "AAMVA raised #{err.class} waiting for security token response: #{err.message}"

--- a/lib/aamva/request/templates/authentication_token.xml.erb
+++ b/lib/aamva/request/templates/authentication_token.xml.erb
@@ -7,7 +7,7 @@
       urn:uuid:<%= uuid %>
     </MessageID>
     <To xmlns="http://www.w3.org/2005/08/addressing">
-      https://authentication-cert.aamva.org/Authentication/Authenticate.svc
+      <%= url %>
     </To>
     <ReplyTo xmlns="http://www.w3.org/2005/08/addressing">
       <Address>http://www.w3.org/2005/08/addressing/anonymous</Address>

--- a/lib/aamva/request/templates/security_token.xml.erb
+++ b/lib/aamva/request/templates/security_token.xml.erb
@@ -2,7 +2,7 @@
   <soap:Header>
     <Action xmlns="http://www.w3.org/2005/08/addressing">http://schemas.xmlsoap.org/ws/2005/02/trust/RST/SCT</Action>
     <MessageID xmlns="http://www.w3.org/2005/08/addressing">urn:uuid:<%= uuid %></MessageID>
-    <To xmlns="http://www.w3.org/2005/08/addressing" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="_<%= message_to_uuid %>">https://authentication-cert.aamva.org/Authentication/Authenticate.svc</To>
+    <To xmlns="http://www.w3.org/2005/08/addressing" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="_<%= message_to_uuid %>"><%= url %></To>
     <ReplyTo xmlns="http://www.w3.org/2005/08/addressing">
       <Address>http://www.w3.org/2005/08/addressing/anonymous</Address>
     </ReplyTo>
@@ -51,7 +51,7 @@
       <wst:RequestType>http://schemas.xmlsoap.org/ws/2005/02/trust/Issue</wst:RequestType>
       <wsp:AppliesTo xmlns:wsp="http://www.w3.org/ns/ws-policy">
         <wsa:EndpointReference xmlns:wsa="http://www.w3.org/2005/08/addressing">
-          <wsa:Address>https://authentication-cert.aamva.org/Authentication/Authenticate.svc</wsa:Address>
+          <wsa:Address><%= url %></wsa:Address>
         </wsa:EndpointReference>
       </wsp:AppliesTo>
       <wst:Lifetime xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">

--- a/spec/fixtures/requests/authentication_token_request.xml
+++ b/spec/fixtures/requests/authentication_token_request.xml
@@ -7,7 +7,7 @@
       urn:uuid:12345678-abcd-efgh-ijkl-1234567890ab
     </MessageID>
     <To xmlns="http://www.w3.org/2005/08/addressing">
-      https://authentication-cert.aamva.org/Authentication/Authenticate.svc
+      https://authentication-cert.example.com/Authentication/Authenticate.svc
     </To>
     <ReplyTo xmlns="http://www.w3.org/2005/08/addressing">
       <Address>http://www.w3.org/2005/08/addressing/anonymous</Address>

--- a/spec/fixtures/requests/security_token_request.xml
+++ b/spec/fixtures/requests/security_token_request.xml
@@ -2,7 +2,7 @@
   <soap:Header>
     <Action xmlns="http://www.w3.org/2005/08/addressing">http://schemas.xmlsoap.org/ws/2005/02/trust/RST/SCT</Action>
     <MessageID xmlns="http://www.w3.org/2005/08/addressing">urn:uuid:12345678-abcd-efgh-ijkl-1234567890ab</MessageID>
-    <To xmlns="http://www.w3.org/2005/08/addressing" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="_12345678-abcd-efgh-ijkl-1234567890ab">https://authentication-cert.aamva.org/Authentication/Authenticate.svc</To>
+    <To xmlns="http://www.w3.org/2005/08/addressing" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="_12345678-abcd-efgh-ijkl-1234567890ab">https://authentication-cert.example.com/Authentication/Authenticate.svc</To>
     <ReplyTo xmlns="http://www.w3.org/2005/08/addressing">
       <Address>http://www.w3.org/2005/08/addressing/anonymous</Address>
     </ReplyTo>
@@ -34,7 +34,7 @@
               </ds:Transform>
             </ds:Transforms>
             <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
-            <ds:DigestValue>0ym9+h240usFC2QKKe/ivmid5kc=</ds:DigestValue>
+            <ds:DigestValue>uIfPouaveIZdBSvpP7FSAky/srg=</ds:DigestValue>
           </ds:Reference>
         </ds:SignedInfo>
         <ds:SignatureValue></ds:SignatureValue>
@@ -51,7 +51,7 @@
       <wst:RequestType>http://schemas.xmlsoap.org/ws/2005/02/trust/Issue</wst:RequestType>
       <wsp:AppliesTo xmlns:wsp="http://www.w3.org/ns/ws-policy">
         <wsa:EndpointReference xmlns:wsa="http://www.w3.org/2005/08/addressing">
-          <wsa:Address>https://authentication-cert.aamva.org/Authentication/Authenticate.svc</wsa:Address>
+          <wsa:Address>https://authentication-cert.example.com/Authentication/Authenticate.svc</wsa:Address>
         </wsa:EndpointReference>
       </wsp:AppliesTo>
       <wst:Lifetime xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">


### PR DESCRIPTION
**Why**: These URLs are in the signed part of the request. AAMVA verifies them to make sure that the request was built for the current service. Having them hardcoded causes this check to fail if the URL of the authentication service changes.