### PR TITLE
Add automatic retry of verify request (LG-3051)

### DIFF
--- a/aamva-api-client.gemspec
+++ b/aamva-api-client.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency('dotenv')
   s.add_dependency('faraday')
   s.add_dependency('hashie')
+  s.add_dependency('retries')
   s.add_dependency('typhoeus')
   s.add_dependency('xmldsig')
 

--- a/lib/aamva/request/verification_request.rb
+++ b/lib/aamva/request/verification_request.rb
@@ -3,8 +3,8 @@ require 'faraday'
 require 'rexml/document'
 require 'rexml/xpath'
 require 'securerandom'
-require 'typhoeus/adapters/faraday'
 require 'retries'
+require 'typhoeus/adapters/faraday'
 
 module Aamva
   module Request

--- a/lib/aamva/request/verification_request.rb
+++ b/lib/aamva/request/verification_request.rb
@@ -4,7 +4,7 @@ require 'rexml/document'
 require 'rexml/xpath'
 require 'securerandom'
 require 'typhoeus/adapters/faraday'
-
+require 'retries'
 
 module Aamva
   module Request
@@ -28,9 +28,11 @@ module Aamva
       end
 
       def send
-        Response::VerificationResponse.new(
-          http_client.post(url, body, headers)
-        )
+        with_retries(max_tries: 2, rescue: [Faraday::TimeoutError, Faraday::ConnectionFailed]) do
+          Response::VerificationResponse.new(
+            http_client.post(url, body, headers)
+          )
+        end
       rescue Faraday::TimeoutError, Faraday::ConnectionFailed => err
         message = "AAMVA raised #{err.class} waiting for verification response: #{err.message}"
         raise ::Proofer::TimeoutError, message

--- a/lib/aamva/version.rb
+++ b/lib/aamva/version.rb
@@ -1,3 +1,3 @@
 module Aamva
-  VERSION = '3.3.0'.freeze
+  VERSION = '3.4.0'.freeze
 end

--- a/spec/lib/aamva/request/authentication_token_request_spec.rb
+++ b/spec/lib/aamva/request/authentication_token_request_spec.rb
@@ -57,7 +57,19 @@ describe Aamva::Request::AuthenticationTokenRequest do
       end
     end
 
-    context 'when the request times out' do
+    context 'when the request times out once' do
+      it 'retries and tries again' do
+        stub_request(:post, Aamva::Request::AuthenticationTokenRequest.auth_url).
+          to_timeout.
+          to_return(body: Fixtures.authentication_token_response, status: 200)
+
+        result = subject.send
+
+        expect(result.auth_token).to eq('KEYKEYKEY')
+      end
+    end
+
+    context 'when the request times out a second time' do
       it 'raises an error' do
         stub_request(:post, Aamva::Request::AuthenticationTokenRequest.auth_url).
           to_timeout

--- a/spec/lib/aamva/request/security_token_request_spec.rb
+++ b/spec/lib/aamva/request/security_token_request_spec.rb
@@ -65,7 +65,19 @@ describe Aamva::Request::SecurityTokenRequest do
       end
     end
 
-    context 'when the request times out' do
+    context 'when the request times out once' do
+      it 'retries and tries again' do
+        stub_request(:post, Aamva::Request::SecurityTokenRequest.auth_url).
+          to_timeout.
+          to_return(body: Fixtures.security_token_response, status: 200)
+
+        result = subject.send
+
+        expect(result.nonce).to eq('MTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTE=')
+      end
+    end
+
+    context 'when the request times out a second time' do
       it 'raises an error' do
         stub_request(:post, Aamva::Request::SecurityTokenRequest.auth_url).
           to_timeout

--- a/spec/lib/aamva/request/verification_request_spec.rb
+++ b/spec/lib/aamva/request/verification_request_spec.rb
@@ -68,7 +68,19 @@ describe Aamva::Request::VerificationRequest do
       end
     end
 
-    context 'when the request times out' do
+    context 'when the request times out once' do
+      it 'retries and tries again' do
+        stub_request(:post, Aamva::Request::VerificationRequest.verification_url).
+          to_timeout.
+          to_return(body: Fixtures.verification_response, status: 200)
+
+        result = subject.send
+
+        expect(result.success?).to eq(true)
+      end
+    end
+
+    context 'when the request times out a second time' do
       it 'raises an error' do
         stub_request(:post, Aamva::Request::VerificationRequest.verification_url).
           to_timeout

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ $LOAD_PATH.unshift File.dirname(__FILE__) + '/../lib'
 require 'pry-byebug'
 require 'dotenv'
 require 'webmock/rspec'
+require 'retries'
 
 require 'proofer'
 require 'aamva'
@@ -11,6 +12,7 @@ require 'aamva'
 Dir[File.dirname(__FILE__) + '/support/*.rb'].sort.each { |file| require file }
 
 EnvOverrides.set_test_environment_variables
+Retries.sleep_enabled = false
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
LG-3051: add automatic retry

This builds on #32 

View the [incremental diff](https://github.com/18F/identity-aamva-api-client-gem/compare/margolis-webmock...margolis-automatic-retry)

