### PR TITLE
Update capitalization in TransactionLocatorId (LG-4257)

### DIFF
--- a/lib/aamva/response/verification_response.rb
+++ b/lib/aamva/response/verification_response.rb
@@ -70,13 +70,14 @@ module Aamva
         raise VerificationError, error_handler.error_message
       end
 
-      def node_for_match_indicator(match_indicator_name)
-        REXML::XPath.first(rexml_document, "//#{match_indicator_name}")
+      def node_for_match_indicator(match_indicator_name, namespace: nil)
+        REXML::XPath.first(rexml_document, "//#{match_indicator_name}") ||
+          (namespace && REXML::XPath.first(rexml_document, "//ns:#{match_indicator_name}", ns: namespace))
       end
 
       def parse_response
         VERIFICATION_ATTRIBUTES_MAP.each_pair do |match_indicator_name, attribute_name|
-          attribute_node = node_for_match_indicator(match_indicator_name)
+          attribute_node = node_for_match_indicator(match_indicator_name, namespace: 'http://aamva.org/niem/extensions/1.0')
           if attribute_node.nil?
             handle_missing_attribute(attribute_name)
           elsif attribute_node.text == 'true'
@@ -86,7 +87,10 @@ module Aamva
           end
         end
 
-        @transaction_locator_id = node_for_match_indicator('TransactionLocatorID')&.text
+        @transaction_locator_id = (
+          node_for_match_indicator('TransactionLocatorId', namespace: 'http://aamva.org/dldv/wsdl/2.1') ||
+            node_for_match_indicator('TransactionLocatorID', namespace: 'http://aamva.org/dldv/wsdl/2.1')
+        )&.text
       end
 
       def rexml_document

--- a/lib/aamva/response/verification_response.rb
+++ b/lib/aamva/response/verification_response.rb
@@ -70,14 +70,13 @@ module Aamva
         raise VerificationError, error_handler.error_message
       end
 
-      def node_for_match_indicator(match_indicator_name, namespace: nil)
-        REXML::XPath.first(rexml_document, "//#{match_indicator_name}") ||
-          (namespace && REXML::XPath.first(rexml_document, "//ns:#{match_indicator_name}", ns: namespace))
+      def node_for_match_indicator(match_indicator_name)
+        REXML::XPath.first(rexml_document, "//#{match_indicator_name}")
       end
 
       def parse_response
         VERIFICATION_ATTRIBUTES_MAP.each_pair do |match_indicator_name, attribute_name|
-          attribute_node = node_for_match_indicator(match_indicator_name, namespace: 'http://aamva.org/niem/extensions/1.0')
+          attribute_node = node_for_match_indicator(match_indicator_name)
           if attribute_node.nil?
             handle_missing_attribute(attribute_name)
           elsif attribute_node.text == 'true'
@@ -88,8 +87,8 @@ module Aamva
         end
 
         @transaction_locator_id = (
-          node_for_match_indicator('TransactionLocatorId', namespace: 'http://aamva.org/dldv/wsdl/2.1') ||
-            node_for_match_indicator('TransactionLocatorID', namespace: 'http://aamva.org/dldv/wsdl/2.1')
+          node_for_match_indicator('TransactionLocatorId') ||
+            node_for_match_indicator('TransactionLocatorID')
         )&.text
       end
 

--- a/lib/aamva/version.rb
+++ b/lib/aamva/version.rb
@@ -1,3 +1,3 @@
 module Aamva
-  VERSION = '3.5.0'.freeze
+  VERSION = '3.6.0'.freeze
 end

--- a/spec/fixtures/responses/verification_response_namespaced_failure.xml
+++ b/spec/fixtures/responses/verification_response_namespaced_failure.xml
@@ -1,0 +1,22 @@
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://www.w3.org/2005/08/addressing">
+  <s:Header>
+    <a:Action s:mustUnderstand="1">
+      http://aamva.org/dldv/wsdl/2.1/IDLDVService21/VerifyDriverLicenseDataResponse
+    </a:Action>
+    <a:MessageID>uuid:1111111111111111    1UNISG</a:MessageID>
+  </s:Header>
+  <s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <VerifyDriverLicenseDataResponse xmlns="http://aamva.org/dldv/wsdl/2.1">
+      <VerifyDriverLicenseDataResult>
+        <ControlData xmlns="http://aamva.org/niem/extensions/1.0">
+          <MessageAddress>
+            <TransactionLocatorId>transaction-locator-id-12345</TransactionLocatorId>
+            <MessageOriginatorId>WI</MessageOriginatorId>
+            <MessageDestinationId>GSA</MessageDestinationId>
+          </MessageAddress>
+        </ControlData>
+        <DriverLicenseNumberMatchIndicator xmlns="http://aamva.org/niem/extensions/1.0">false</DriverLicenseNumberMatchIndicator>
+      </VerifyDriverLicenseDataResult>
+    </VerifyDriverLicenseDataResponse>
+  </s:Body>
+</s:Envelope>

--- a/spec/fixtures/responses/verification_response_namespaced_success.xml
+++ b/spec/fixtures/responses/verification_response_namespaced_success.xml
@@ -1,0 +1,26 @@
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://www.w3.org/2005/08/addressing">
+  <s:Header>
+    <a:Action s:mustUnderstand="1">
+      http://aamva.org/dldv/wsdl/2.1/IDLDVService21/VerifyDriverLicenseDataResponse
+    </a:Action>
+    <a:MessageID>uuid:1111111111111111    1UNISG</a:MessageID>
+  </s:Header>
+  <s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <VerifyDriverLicenseDataResponse xmlns="http://aamva.org/dldv/wsdl/2.1">
+      <VerifyDriverLicenseDataResult>
+        <ControlData xmlns="http://aamva.org/niem/extensions/1.0">
+          <MessageAddress>
+            <TransactionLocatorId>transaction-locator-id-67890</TransactionLocatorId>
+            <MessageOriginatorId>WI</MessageOriginatorId>
+            <MessageDestinationId>GSA</MessageDestinationId>
+          </MessageAddress>
+        </ControlData>
+        <DriverLicenseNumberMatchIndicator xmlns="http://aamva.org/niem/extensions/1.0">true</DriverLicenseNumberMatchIndicator>
+        <PersonBirthDateMatchIndicator xmlns="http://aamva.org/niem/extensions/1.0">true</PersonBirthDateMatchIndicator>
+        <PersonLastNameExactMatchIndicator xmlns="http://aamva.org/niem/extensions/1.0">true</PersonLastNameExactMatchIndicator>
+        <PersonFirstNameExactMatchIndicator xmlns="http://aamva.org/niem/extensions/1.0">true</PersonFirstNameExactMatchIndicator>
+      </VerifyDriverLicenseDataResult>
+    </VerifyDriverLicenseDataResponse>
+  </s:Body>
+</s:Envelope>
+

--- a/spec/lib/aamva/response/verification_response_spec.rb
+++ b/spec/lib/aamva/response/verification_response_spec.rb
@@ -49,9 +49,17 @@ describe Aamva::Response::VerificationResponse do
   end
 
   describe '#reasons' do
-    context 'when all attiutes are verified' do
+    context 'when all attributes are verified' do
       it 'returns an empty array' do
         expect(subject.reasons).to eq([])
+      end
+
+      context 'with a namespaced XML body' do
+        let(:response_body) { Fixtures.verification_response_namespaced_success }
+
+        it 'returns an empty array' do
+          expect(subject.reasons).to eq([])
+        end
       end
     end
 
@@ -82,8 +90,21 @@ describe Aamva::Response::VerificationResponse do
         )
       end
 
-      it 'returns an array with the reasons verifiation failed' do
+      it 'returns an array with the reasons verification failed' do
         expect(subject.reasons).to eq(['Failed to verify dob', 'Response was missing first_name'])
+      end
+
+      context 'with a namespaced XML response' do
+        let(:response_body) { Fixtures.verification_response_namespaced_failure }
+
+        it 'returns an array with the reasons verification failed' do
+          expect(subject.reasons).to eq([
+            'Failed to verify state_id_number',
+            'Response was missing dob',
+            'Response was missing last_name',
+            'Response was missing first_name'
+          ])
+        end
       end
     end
   end
@@ -103,6 +124,11 @@ describe Aamva::Response::VerificationResponse do
       end
 
       it { expect(subject.success?).to eq(true) }
+
+      context 'with a namespaced XML response' do
+        let(:response_body) { Fixtures.verification_response_namespaced_success }
+        it { expect(subject.success?).to eq(true) }
+      end
     end
 
     context 'when required attributes are not verified' do
@@ -174,6 +200,22 @@ describe Aamva::Response::VerificationResponse do
 
       it 'is nil' do
         expect(subject.transaction_locator_id).to be_nil
+      end
+    end
+
+    context 'with a namespaced XML response' do
+      let(:response_body) { Fixtures.verification_response_namespaced_success }
+
+      it 'is the value from the response' do
+        expect(subject.transaction_locator_id).to eq('transaction-locator-id-67890')
+      end
+    end
+
+    context 'with a namespaced XML failure response' do
+      let(:response_body) { Fixtures.verification_response_namespaced_failure }
+
+      it 'is the value from the response' do
+        expect(subject.transaction_locator_id).to eq('transaction-locator-id-12345')
       end
     end
   end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -76,6 +76,14 @@ module Fixtures
     read_fixture_file('responses/verification_response.xml')
   end
 
+  def self.verification_response_namespaced_success
+    read_fixture_file('responses/verification_response_namespaced_success.xml')
+  end
+
+  def self.verification_response_namespaced_failure
+    read_fixture_file('responses/verification_response_namespaced_failure.xml')
+  end
+
   private_class_method def self.read_fixture_file(path)
     fullpath = File.join(
       File.dirname(__FILE__),


### PR DESCRIPTION
Testing in staging revealed that AAMVA seems to be giving us different responses than we had in fixtures previously:

1. lowercase `TransactionLocatorId` vs what we had previously `TransactionLocatorID`

~2. XML namespaces! Our favorite, `xmlns` makes querying for tags a little trickier, previous fixtures didn't include namespace at all, but the current response seemed to have a lot of them, so this updates that.~ 

~As a note, I wrote this code as `without_namespace || with_namespace` just in case the old fixtures are out there too? Or maybe we're failing too many people IRL because our code didn't handle these namespaces?~

- **update**: the namepacing stuff seems to not be an issue, it was all a capitalization issue


Compare new:
https://github.com/18F/identity-aamva-api-client-gem/blob/cca839355bf74db4f70208e12593d38503b9208c/spec/fixtures/responses/verification_response_namespaced_success.xml
to existing:
https://github.com/18F/identity-aamva-api-client-gem/blob/90c378604f762ee3099a44d5680d5939806e6928/spec/fixtures/responses/verification_response.xml