### PR TITLE
Use RedactedStruct for config

### DIFF
--- a/aamva-api-client.gemspec
+++ b/aamva-api-client.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency('hashie')
   s.add_dependency('retries')
   s.add_dependency('xmldsig')
+  s.add_dependency('redacted_struct', '>= 1.0.0')
 
   # This should be identity-proofer when we rename what the gem exports itself as
   s.add_dependency('proofer', '>= 2.7.1')

--- a/lib/aamva/proofer.rb
+++ b/lib/aamva/proofer.rb
@@ -1,9 +1,10 @@
 require 'ostruct'
 require 'proofer'
+require 'redacted_struct'
 
 module Aamva
   class Proofer < Proofer::Base
-    Config = Struct.new(
+    Config = RedactedStruct.new(
       :auth_request_timeout,
       :auth_url,
       :cert_enabled,
@@ -12,6 +13,13 @@ module Aamva
       :verification_request_timeout,
       :verification_url,
       keyword_init: true,
+      allowed_members: [
+        :auth_request_timeout,
+        :auth_url,
+        :cert_enabled,
+        :verification_request_timeout,
+        :verification_url,
+      ],
     )
 
     attr_reader :config

--- a/lib/aamva/version.rb
+++ b/lib/aamva/version.rb
@@ -1,3 +1,3 @@
 module Aamva
-  VERSION = '4.1.0'.freeze
+  VERSION = '4.2.0'.freeze
 end


### PR DESCRIPTION
**Why**: To minimize the chances we accidentally log sensitive credentials